### PR TITLE
Unify Docker Bash scripts and simplify Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**/*.json
+**/*.geojson
+**/*.csv
+**/*.CSV
+**/*.zip
+**/*.pdf
+**/*.xlsx
+**/*.docx
+**/*.txt
+!**/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 # Data generated in the notebook directory. All committed data should be in the data/ folder.
-nbs/*.json*
-nbs/*.geojson*
-nbs/*.csv*
+nbs/**/*.json*
+nbs/**/*.geojson*
+nbs/**/*.csv*
+nbs/**/*.zip*
+nbs/**/*.pdf*
+nbs/**/*.xlsx*
+nbs/**/*.docx*
+nbs/**/*.txt*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,30 +1,14 @@
-FROM osgeo/gdal:ubuntu-full-v2.5.0RC1
-ARG PYTHON_VERSION=3.6
+FROM python:3
 
-RUN apt-get update && apt-get install -y software-properties-common
-
-ENV TZ=Europe/Minsk
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN add-apt-repository ppa:ubuntugis/ppa && \
-     apt-get update && \
-     apt-get install -y wget=1.* git=1:2.* python-protobuf \
-     jq=1.5* \
-     build-essential libsqlite3-dev zlib1g-dev=1:1.2.* libspatialindex-dev && \
-     apt-get autoremove && apt-get autoclean && apt-get clean
-
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh
-
-ENV PATH /opt/conda/bin:$PATH
-RUN conda install -y python=$PYTHON_VERSION
-RUN conda install -y -c conda-forge awscli=1.16.* boto3=1.9.*
-RUN conda clean -ya
-
-# Install required libraries
-#RUN apt-get install -y python3-rtree
+RUN apt-get update && apt-get install --no-install-recommends -y \
+     libspatialindex-dev \
+     unzip && \
+     rm -rf /var/lib/apt/lists/*
 
 COPY nbs/requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
+
+WORKDIR /opt/src
+
+ENTRYPOINT [ "jupyter" ]
+CMD [ "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--notebook-dir=/opt/jupyter" ]

--- a/docker/build
+++ b/docker/build
@@ -2,10 +2,14 @@
 
 set -e
 
+if [[ -n "${COVID19_DEBUG}" ]]; then
+    set -x
+fi
+
 function usage() {
 
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Setup project containers.
 "
 }
@@ -15,10 +19,8 @@ function build_containers() {
     docker build -t covid19 -f docker/Dockerfile .
 }
 
-if [ "${BASH_SOURCE[0]}" = "${0}" ]
-then
-    if [ "${1:-}" = "--help" ]
-    then
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
         usage
     else
         build_containers

--- a/docker/console
+++ b/docker/console
@@ -6,31 +6,26 @@ if [[ -n "${COVID19_DEBUG}" ]]; then
     set -x
 fi
 
-
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
-SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-PROJECT_ROOT="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+while [ -h "$SOURCE" ]; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+PROJECT_ROOT="$(cd -P "$(dirname "$SCRIPTS_DIR")" && pwd)"
 
 DATA_DIR="${COVID19_DATA_DIR:-${PROJECT_ROOT}/data}"
 NOTEBOOK_DIR="${COVID19_NOTEBOOK_DIR:-${PROJECT_ROOT}/nbs}"
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0")
-Run the jupyter notebook in a covid19 docker image locally
+        "Usage: $(basename "$0")
+Launch Bash within the Jupyter container image.
 "
 }
 
-if [ "${BASH_SOURCE[0]}" = "${0}" ]
-then
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     docker run --rm -it \
-           -e "AWS_PROFILE=$AWS_PROFILE" \
-           -v "$HOME/.aws":/root/.aws:ro \
-           -v "$PROJECT_ROOT":/home/jovyan/src \
-           -v ${DATA_DIR}:/home/jovyan/data \
-           -v ${NOTEBOOK_DIR}:/home/jovyan/nbs \
-           --ip 0.0.0.0 \
-           covid19:latest \
-           /bin/bash
+        -v "$PROJECT_ROOT":/opt/src \
+        -v "$DATA_DIR":/opt/jupyter/data \
+        -v "$NOTEBOOK_DIR":/opt/jupyter/nbs \
+        --entrypoint /bin/bash \
+        covid19:latest
 fi

--- a/docker/notebook
+++ b/docker/notebook
@@ -6,36 +6,26 @@ if [[ -n "${COVID19_DEBUG}" ]]; then
     set -x
 fi
 
-
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
-SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-PROJECT_ROOT="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+while [ -h "$SOURCE" ]; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+PROJECT_ROOT="$(cd -P "$(dirname "$SCRIPTS_DIR")" && pwd)"
 
 DATA_DIR="${COVID19_DATA_DIR:-${PROJECT_ROOT}/data}"
 NOTEBOOK_DIR="${COVID19_NOTEBOOK_DIR:-${PROJECT_ROOT}/nbs}"
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0")
-Run the jupyter notebook in a covid19 docker image locally
+        "Usage: $(basename "$0")
+Launch Jupyter notebooks.
 "
 }
 
-JUPYTER="-v ${NOTEBOOK_DIR}:/opt/jupyter -p 8888:8888"
-CMD=(jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --allow-root --notebook-dir=/opt/jupyter)
-
-
-if [ "${BASH_SOURCE[0]}" = "${0}" ]
-then
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     docker run --rm -it \
-           -e "AWS_PROFILE=$AWS_PROFILE" \
-           -v "$HOME/.aws":/root/.aws:ro \
-           -v "$PROJECT_ROOT":/opt/src \
-           -v ${DATA_DIR}:/opt/jupyter/data \
-           -v ${NOTEBOOK_DIR}:/opt/jupyter/nbs \
-           --ip 0.0.0.0 \
-           -p 8888:8888 \
-           covid19:latest \
-           "${CMD[@]}"
+        -v "$PROJECT_ROOT":/opt/src \
+        -v "$DATA_DIR":/opt/jupyter/data \
+        -v "$NOTEBOOK_DIR":/opt/jupyter/nbs \
+        -p 8888:8888 \
+        covid19:latest
 fi


### PR DESCRIPTION
Use `shfmt` and `shellcheck` against all Bash scripts and unify the way each invokes the Docker CLI.

In addition, simplify the Docker setup by:

- Inheriting from `python:3` in the `Dockerfile`
- Setting Jupyter notebook mode as the default `ENTRYPOINT`/`CMD`
- Adding a `.dockerignore` to reduce the costs of repeated image rebuilds

I tested with `docker/build` and `docker/notebook` to confirm that these changes did not break things in a devastating way:

- `usa_beds_capacity_analysis_20200313_v2.ipynb` appeared to complete successfully.
- `usa_hcris2018_facilitybedcounts_20200313_v1.ipynb` got far, but got stuck on an index out of bounds error in the cell that starts with the following

```python
beds_list = []
beddays_list = []
ptdays_list = []

for idx, provider_num in hosp_df['PROVIDER_NUMBER'].items():

. . .
```

If this is a regression, I can take a closer look later. For now, I'll leave things as a draft PR.